### PR TITLE
Fix macos inconsistency

### DIFF
--- a/src/mspass_launcher/data/yaml/MsPASSDesktopGUI.yaml
+++ b/src/mspass_launcher/data/yaml/MsPASSDesktopGUI.yaml
@@ -5,7 +5,7 @@ log_window_size_y: 4           # vertical size of Text widget log windows - numb
 grid_padding:  5               # padding in pixels to use for padx and pady values in grid geometry setups
 # docker compose definitions must be in this additional file
 docker_compose_yaml_file: DesktopCluster.yaml
-engine_startup_delay:  5       # seconds to wait during startup before trying fi check status
+engine_startup_delay_time:  5       # seconds to wait during startup before trying fi check status
 status_monitor_time_interval:  10  # Number of seconds between tests for status of all running containers
 web_browser:  firefox         # use if the name resolves in the shell.  Comment out this line for MacOS and Windows
 # normal docker usage binds current directory to a fixed mount point (default /home) 

--- a/src/mspass_launcher/desktop.py
+++ b/src/mspass_launcher/desktop.py
@@ -189,7 +189,6 @@ class MsPASSDesktopCluster:
         runline.append("python")
         runline.append(filename)
         try:
-            print("Debug: ",runline)
             runout = subprocess.run(runline,capture_output=True,text=True,check=True)
             if return_output:
                 return runout.stdout
@@ -493,11 +492,8 @@ class MsPASSDesktopGUI:
         time, and then launches the status monitor.  Finally, it enables the 
         work other buttons and disable itself before exiting.  
         """
-        print("Testing:  launch button works")
-        print("Launching engine")
         self.engine = MsPASSDesktopCluster(configuration=self.docker_compose_filename)
         self.engine.launch_cluster()
-        print("engine running")
         # needed because otherwise the status monitor will throw an exception if 
         # a service is not defined.  
         # TODO:  this could probably be avoided by letting undefined make status red with a different label
@@ -519,7 +515,6 @@ class MsPASSDesktopGUI:
         It tries to launch the jupyter lab browser window. 
         It also inserts the url it resolves into the url text widget. 
         """
-        print("Testing:  Jupyter button works")
         self.engine.launch_jupyter_client(self.browser)
         jupyter_url = self.engine.url()
         self.text_url.insert("1.0",jupyter_url)
@@ -532,7 +527,6 @@ class MsPASSDesktopGUI:
         same approach as the jupyter lab launcher for resolving the browser.  
         If the Jupyter button doesn't work this one won't either. 
         """
-        print("Testing:  Diagnostic button works")
         jupyter_url = self.engine.url()
         # if valid the url always has this magic string
         anchor = "lab?token="
@@ -618,7 +612,6 @@ class MsPASSDesktopGUI:
         
         This method opens a new window and build the run window gui.   
         """
-        print("Testing:  run button works with hello.py script")
         self.run_window = tk.Toplevel()
         self.frm_run_entries = tk.Frame(self.run_window, relief=tk.RAISED, bd=2)
         self.label_dir_name = tk.Label(self.frm_run_entries,text="Directory inside container where script can be found")
@@ -635,9 +628,6 @@ class MsPASSDesktopGUI:
         
         self.btn_run_script = tk.Button(self.run_window, text="Run it", command=self.container_run_callback)
         self.btn_run_script.pack()
-        #fullpath = self.container_run_directory + "/" + "hello.py"
-        #out = self.engine.run(fullpath,return_output=True)
-        #print(out)
     def shutdown_callback(self):
         """
         Method run when the shutdown button is pushed.   
@@ -646,7 +636,6 @@ class MsPASSDesktopGUI:
         lab and dask diagnostic windows in a web browser.  The diagnostics window will still function 
         on a restart but the jupyter server will not.  
         """
-        print("Testing:  Shutdown button works")
         # this must be done first to kill the monitor thread
         # sleep to match time delay to be sure the monitor thread has exited before
         # the engine is stopped

--- a/src/mspass_launcher/desktop.py
+++ b/src/mspass_launcher/desktop.py
@@ -249,11 +249,16 @@ class MsPASSDesktopCluster:
                     message += "Check docker documentation and consider using an older version of docker until this can be fixed"
                     raise RuntimeError(message)
                 else:
-                    result = json.loads(outlines[0])
+                    jsonout = json.loads(outlines[0])
+                    # docker ps returns a list with a dict inside on some macos versions
+                    # this is needed to handle that anomaly
+                    # note not json.loads issue but what docker ps spit out 
+                    if isinstance(jsonout,list):
+                        jsonout = jsonout[0]
                     if form=="all":
-                        return result
+                        return jsonout
                     else:
-                        return result ["State"]        
+                        return jsonout ["State"]        
         else:
             message = prog + ":  " + "invalid value for arg0={}\n".format(service)
             message += "Must be one of:  mspass-db, mspass-frontend, mspass-scheduler, or mspass-worker"


### PR DESCRIPTION
This branch fixes a weird inconsistency in the return of docker compose ps.  The json format return in linux is parsed as a dict but in macos (or at least some version of docker running on macos) json.loads returns the result as list with one component that contains the dict one sees with the linux version.  Weird inconsistency but easily handled - just added two extra lines of code with isinstance(x,list) and when true extacted x[0] as the dict.  

This also fixes an incorrect key on a data file and changes the name of MsPASSGUI.yaml to MsPASSDesktopGUI.yaml to match defaults for the python code. 