### PR TITLE
Improve datafile

### DIFF
--- a/src/mspass_launcher/data/yaml/MsPASSDesktopGUI.yaml
+++ b/src/mspass_launcher/data/yaml/MsPASSDesktopGUI.yaml
@@ -1,13 +1,21 @@
-minimum_window_size_x: 1000    # horizontal minimum size in pixels
-minimum_window_size_y: 1000    # vertical minimum size in pixels
-log_window_size_x: 128         # horizontal size of Text widget log windows in characters
-log_window_size_y: 4           # vertical size of Text widget log windows - number of lines
-grid_padding:  5               # padding in pixels to use for padx and pady values in grid geometry setups
+# Minimum horizontal size of main window in pixels
+minimum_window_size_x: 1000    
+# Minimum vertical size of main window in pixels
+minimum_window_size_y: 1000  
+# padding in pixels for widget frames
+grid_padding:  5               
 # docker compose definitions must be in this additional file
+# follows same search rules as search for this file
 docker_compose_yaml_file: DesktopCluster.yaml
-engine_startup_delay_time:  5       # seconds to wait during startup before trying fi check status
-status_monitor_time_interval:  10  # Number of seconds between tests for status of all running containers
-web_browser:  firefox         # use if the name resolves in the shell.  Comment out this line for MacOS and Windows
+# A short wait is required before running status checks
+# without this delay the launcher can throw an exception
+# Change only if you are on a slow machine that is aborting on startup
+engine_startup_delay_time:  5     
+# The status of each service container is checked at this interval in seconds
+status_monitor_time_interval:  10 
+# Name of web browser - auto launching only works if this name resolves
+# in the shell
+web_browser:  firefox
 # normal docker usage binds current directory to a fixed mount point (default /home) 
 # this needs to point to the alias in the container NOT the path in the parent file system
 container_run_directory:  /home

--- a/src/mspass_launcher/desktop.py
+++ b/src/mspass_launcher/desktop.py
@@ -75,7 +75,7 @@ class MsPASSDesktopCluster:
         yaml configuration file to be stored other than in the current
         directory.
         """
-        self.docker_configuration_file = mspass_yaml_file(configuration)
+        self.docker_configuration_file = datafile(configuration)
 
     def launch_cluster(self):
         """
@@ -380,8 +380,6 @@ class MsPASSDesktopGUI:
         self.docker_compose_filename = self.config_data["docker_compose_yaml_file"]
         self.minsize_x = self.config_data["minimum_window_size_x"]
         self.minsize_y = self.config_data["minimum_window_size_y"]
-        self.log_window_size_x = self.config_data["log_window_size_x"]
-        self.log_window_size_y = self.config_data["log_window_size_y"]
         self.grid_padding = self.config_data["grid_padding"]
         self.engine_startup_delay_time = self.config_data["engine_startup_delay_time"]
         self.status_monitor_time_interval = self.config_data[
@@ -861,56 +859,6 @@ def extract_jupyter_url(outstr) -> str:
     return "http://localhost:8888"
 
 
-def mspass_yaml_file(filename) -> str:
-    """
-    Performs a standard search for a yaml file in MsPASS.
-
-    This functions standardizes
-    the search for the file to be read in the same way used in the
-    MsPASS Schema constructor.   That is, if filename is set to
-    a valid string the function assumes the string defines a file
-    name in the current directory.  If that file does not exist there
-    the function tries searching for the same file in two places:
-        1) $MSPASS_HOME/data/yaml is used if and only if MSPASS_HOME
-           is defined.
-        2) MSPASS_INSTALL_DIR/data/yaml where MSPASS_INSTALL_DIR
-           is the top level directory of where mspass was installed
-           in your system.  This works because the installation tree
-           has a data/yaml directory with defaults yaml files.
-
-    Note the function does NOT test for existence of the file
-    name or path it returns.  Caller should handle that condition
-    if necessary.
-
-    :param filename:   name of file to find
-    :type filename:  str
-    :return:  str containg a full path to file.
-    """
-    if not isinstance(filename, str):
-        message = "mspass_yaml_file:  arg0 must be a string defining a file name\n"
-        message += "Actual type={}".format(type(filename))
-        raise TypeError(message)
-    # note this resolves true if filename is a file in the current
-    # directory or an absolute path to some file
-    if os.path.isfile(filename):
-        config_file = filename
-    else:
-        if "MSPASS_HOME" in os.environ:
-            config_file = os.path.join(
-                os.path.abspath(os.environ["MSPASS_HOME"]),
-                "data/yaml",
-                filename,
-            )
-        else:
-            config_file = os.path.abspath(
-                os.path.join(
-                    os.path.dirname(__file__),
-                    "../data/yaml",
-                    filename,
-                )
-            )
-    return config_file
-
 
 def parse_yaml_file(filename=None, 
                     default_file_name="MsPASSDesktopGUI.yaml",
@@ -950,7 +898,7 @@ def parse_yaml_file(filename=None,
         raise RuntimeError(message)
 
     if verbose:
-        prin("Parsing yaml file=",file_path)
+        print("Parsing yaml file=",file_path)
     try:
         with open(file_path, "r") as stream:
             result_dic = yaml.safe_load(stream)

--- a/src/mspass_launcher/desktop.py
+++ b/src/mspass_launcher/desktop.py
@@ -347,6 +347,7 @@ class MsPASSDesktopGUI:
     def __init__(
         self,
         configuration="MsPASSDesktopGUI.yaml",
+        verbose=False,
     ):
         """
         Creates GUI in initial state with launch button enabled and
@@ -372,7 +373,10 @@ class MsPASSDesktopGUI:
 
         # first read yaml file that sets defines some gui
         # configuration data - store this in the dict self.config_data
-        self.config_data = parse_yaml_file(configuration)
+        self.config_data = parse_yaml_file(configuration,verbose=verbose)
+        if verbose:
+            print("MsPASSDesktopGUI configuration parameters:")
+            print(json.dumps(self.config_data,indent=4))
         self.docker_compose_filename = self.config_data["docker_compose_yaml_file"]
         self.minsize_x = self.config_data["minimum_window_size_x"]
         self.minsize_y = self.config_data["minimum_window_size_y"]
@@ -908,7 +912,9 @@ def mspass_yaml_file(filename) -> str:
     return config_file
 
 
-def parse_yaml_file(filename=None, default_file_name="MsPASSDesktopGUI.yaml") -> dict:
+def parse_yaml_file(filename=None, 
+                    default_file_name="MsPASSDesktopGUI.yaml",
+                    verbose=False) -> dict:
     """
     Parses a yaml configuration file with the yaml module.  When
     successful it returns a dict with key-value pairs that the
@@ -943,6 +949,8 @@ def parse_yaml_file(filename=None, default_file_name="MsPASSDesktopGUI.yaml") ->
         )
         raise RuntimeError(message)
 
+    if verbose:
+        prin("Parsing yaml file=",file_path)
     try:
         with open(file_path, "r") as stream:
             result_dic = yaml.safe_load(stream)

--- a/src/mspass_launcher/scripts/mspass_desktop.py
+++ b/src/mspass_launcher/scripts/mspass_desktop.py
@@ -6,11 +6,13 @@ This file containa a main program that creates and uses a GUI for
 launching and controlling MsPASS in a desktop environment.
 
 Usage:
-    mspass [-f configfile]
+    mspass [-f configfile -v]
 
 where configfile is an alternative configuration file for the launcher and
 GUI.   The default uses one found in the default $MSPASSHOME/data/yaml
 diretory called mspass_launcher.yaml.
+
+Use -v to run verbose - echoes configuration data on launch
 
 Created on Sun Apr 27 07:45:54 2025
 
@@ -29,8 +31,8 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     parser = argparse.ArgumentParser(
-        prog="mspass_desktop",
-        usage="%(prog)s [-f configfile",
+        prog="mspass-desktop",
+        usage="%(prog)s [-f configfile -v]",
         description="Launch MsPASS Desktop GUI",
     )
     parser.add_argument(
@@ -40,9 +42,18 @@ def main(args=None):
         default="MsPASSDesktopGUI.yaml",
         help="Change default ",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose mode",
+    )
     args = parser.parse_args(args)
     config_file = args.config_file
-    gui = MsPASSDesktopGUI(configuration=config_file)
+    if args.verbose:
+        gui = MsPASSDesktopGUI(configuration=config_file,verbose=True)
+    else:
+        gui = MsPASSDesktopGUI(configuration=config_file)
 
 
 if __name__ == "__main__":

--- a/src/mspass_launcher/util.py
+++ b/src/mspass_launcher/util.py
@@ -70,6 +70,7 @@ def datafile(
     dirlist = dirs.copy()
     # extend the search if MSPASS_HOME is defined
     mspass_home = os.environ.get("MSPASS_HOME")
+
     if mspass_home:
         for d in dirs:
             split_d = os.path.split(d)
@@ -79,6 +80,16 @@ def datafile(
             # needed to handle . and .. in a path
             dir = os.path.normpath(dir)
             dirlist.append(dir)
+    # Add module install location as a root as final fallback
+    # A bit repetitious of above but not worth an added function overhead
+    package_root_dir = os.path.dirname(__file__)
+    for d in dirs:
+        split_d = os.path.split(d)
+        dir = package_root_dir
+        for sd in split_d:
+            dir = os.path.join(dir,sd)
+        dir = os.path.normpath(dir)
+        dirlist.append(dir)
 
     # now find the first occurence of filename in the list of directories
     for dir in dirlist:


### PR DESCRIPTION
Fixes problems in previous implementation in handling of path for yaml configuration files.   Changed datafile function to include module directory with __file__ python magic.  Now data file first search a default path relative to the current directory, then the module master path, and finally a MSPASS_HOME directory if defined.   